### PR TITLE
Provide to build using with a specific version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM alpine:3.6
 
-ENV VERSION=0.2.2
+ARG VERSION
+ENV VERSION=${VERSION}
 
 RUN apk add --no-cache curl && \
     curl -sSLO https://github.com/awslabs/aws-sam-local/releases/download/v${VERSION}/sam_${VERSION}_linux_386.tar.gz && \


### PR DESCRIPTION
Convenient to specify when using a URL as a parameter to build in docker-compose for example.